### PR TITLE
fix(filter): preserve callable type in filter design

### DIFF
--- a/odl/tomo/analytic/filtered_back_projection.py
+++ b/odl/tomo/analytic/filtered_back_projection.py
@@ -77,19 +77,19 @@ def _fbp_filter(norm_freq, filter_type, frequency_scaling):
     ...                    filter_type='Hann',
     ...                    frequency_scaling=0.8)
     """
-    filter_type, filter_type_in = str(filter_type).lower(), filter_type
+    filter_type_in = str(filter_type).lower()
     if callable(filter_type):
         filt = filter_type(norm_freq)
-    elif filter_type == 'ram-lak':
+    elif filter_type_in == 'ram-lak':
         filt = np.copy(norm_freq)
-    elif filter_type == 'shepp-logan':
+    elif filter_type_in == 'shepp-logan':
         filt = norm_freq * np.sinc(norm_freq / (2 * frequency_scaling))
-    elif filter_type == 'cosine':
+    elif filter_type_in == 'cosine':
         filt = norm_freq * np.cos(norm_freq * np.pi / (2 * frequency_scaling))
-    elif filter_type == 'hamming':
+    elif filter_type_in == 'hamming':
         filt = norm_freq * (
             0.54 + 0.46 * np.cos(norm_freq * np.pi / (frequency_scaling)))
-    elif filter_type == 'hann':
+    elif filter_type_in == 'hann':
         filt = norm_freq * (
             np.cos(norm_freq * np.pi / (2 * frequency_scaling)) ** 2)
     else:


### PR DESCRIPTION
Previously, `filter_type` in `_fbp_filter` was converted to a string before the callable check, causing the condition to always evaluate as false for callable inputs. This change preserves the original object type to ensure correct handling.

Key changes:
1. Removed the assignment `filter_type = str(filter_type).lower()` to preserve the original object type
2. Introduced `filter_type_in` to store the string representation exclusively for predefined filter comparisons
3. Maintained the existing filter type handling logic for strings ('ram-lak', 'shepp-logan', etc.)

The fix ensures:
- Callable filters (e.g., custom functions) are correctly detected by `callable()` and executed
- Predefined filter types continue to function via string matching
- Backward compatibility with existing filter type names